### PR TITLE
alire.toml: fetching new adl_middleware version 0.1.1

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -23,4 +23,4 @@ tags = ["embedded", "nostd"]
 
 [[depends-on]]
 hal = "^0.1.0"
-adl_middleware = "^0.1.0"
+adl_middleware = "^0.1.1"


### PR DESCRIPTION
Hi Fabien,
I would appreciate, if you could check and accept this pull request.
I had to change one line in alire.toml:
fetching adl_middleware 0.1.1
which fixes the 'Update Ada compiler problem resolved by Jeremy.

Thanks and let me know, if you have any questions.